### PR TITLE
docs: add wip banner to how-to guide

### DIFF
--- a/pages/How-to/guide/adding-issue-template.md
+++ b/pages/How-to/guide/adding-issue-template.md
@@ -1,1 +1,3 @@
-
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>

--- a/pages/How-to/guide/adding-pr-template.md
+++ b/pages/How-to/guide/adding-pr-template.md
@@ -1,0 +1,3 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>

--- a/pages/How-to/guide/adding-sponsor.md
+++ b/pages/How-to/guide/adding-sponsor.md
@@ -1,1 +1,4 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>
 

--- a/pages/How-to/guide/assigning-issue.md
+++ b/pages/How-to/guide/assigning-issue.md
@@ -1,1 +1,4 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>
 

--- a/pages/How-to/guide/cloning-repo.md
+++ b/pages/How-to/guide/cloning-repo.md
@@ -1,0 +1,3 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>

--- a/pages/How-to/guide/creating-pr.md
+++ b/pages/How-to/guide/creating-pr.md
@@ -1,1 +1,4 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>
 

--- a/pages/How-to/guide/linking-issue-with-pr.md
+++ b/pages/How-to/guide/linking-issue-with-pr.md
@@ -1,1 +1,4 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>
 

--- a/pages/How-to/guide/rasing-issue.md
+++ b/pages/How-to/guide/rasing-issue.md
@@ -1,0 +1,3 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>

--- a/pages/How-to/guide/reviewing-pr.md
+++ b/pages/How-to/guide/reviewing-pr.md
@@ -1,1 +1,4 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>
 

--- a/pages/How-to/guide/starting-discussion.md
+++ b/pages/How-to/guide/starting-discussion.md
@@ -1,1 +1,4 @@
+<div align="center">
+  <img src="https://user-images.githubusercontent.com/74750414/169188784-680014eb-ae5a-4062-b9c0-40276f28a261.png" />
+</div>
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

Closes #28 

## 👨‍💻 Changes proposed

Added `Work In Progress` banner to all the markdown files in the `pages/How-to/guide/` folder. Now there will be no blank page shown to users.

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

Any fix or suggestions are appreciated :pray: 

## 📷 Screenshots

![image](https://user-images.githubusercontent.com/74750414/169324356-53679c3e-7bac-44f5-8086-2f3186857ff0.png)
