### PR TITLE
repo-private-public

### DIFF
--- a/pages/How-to/guide/repo-private-public.md
+++ b/pages/How-to/guide/repo-private-public.md
@@ -1,3 +1,64 @@
-![WORK IN PROGRESS](https://user-images.githubusercontent.com/51878265/188319718-b341b07b-ef84-4aa3-a8aa-722eb52aff7e.gif)
+# How to make a repository Private/Public
 
-<h4 align="center">If you want to contribute to this page. Please check out the <a href="https://github.com/Pradumnasaraf/open-source-with-pradumna/issues">issues</a></h4>
+There are 2 methods to make a repository public/private.
+- While creating a new repository.
+- Modifying a pre-existing repository.
+
+
+------------
+
+##  Let us look at the Method - 1
+###  Creating a new repository.
+
+
+##### Step 1 : 
+Login to your Github account and click on the **'+'** icon at the top right corner to create a new repository
+
+##### Step 2 :
+Provide any suitable name to the repository
+##### Step 3 :
+Just below you will find 2 options -> **Public** and **Private** and choose the approoriate option
+
+[![Screenshot-2022-10-07-at-16-23-55.png](https://i.postimg.cc/652DFFG3/Screenshot-2022-10-07-at-16-23-55.png)](https://postimg.cc/WhVWkW8L)
+
+##### Step 4 :
+Scroll down and click on **"Create Repository"**
+
+[![Screenshot-2022-10-07-at-16-52-02.png](https://i.postimg.cc/3N0W47n6/Screenshot-2022-10-07-at-16-52-02.png)](https://postimg.cc/p5xP3NNY)
+
+#### Hurray, you just created a new repository 🎉  
+(Based on the option you chose, your repository will be either **Private** or **Public**. )
+
+
+If you want to change the repository visibility setting again, follow the steps below
+
+
+------------
+##  Let us look at the Method - 2
+### Modifying a pre-existing repository.
+##### Step 1 : 
+Open the repository that you want to modify and click on the **"Settings"** option
+
+[![Screenshot-2022-10-07-at-17-02-05.png](https://i.postimg.cc/tgSncBfX/Screenshot-2022-10-07-at-17-02-05.png)](https://postimg.cc/67ZQ2ftS)
+
+##### Step 2 : 
+Scroll down to the botton until you find the **"Danger Zone"** menu and click on the **"Change repository visibility"** option.
+
+[![Screenshot-2022-10-07-at-17-08-04.png](https://i.postimg.cc/wMdN57ZJ/Screenshot-2022-10-07-at-17-08-04.png)](https://postimg.cc/zb038XJX)
+
+##### Step 3 : 
+Choose the option to modify the repository from Public to Private or vice versa, and enter your **"GitHub username/repository name"** to confirm and click on the **I understand, change repository visibility** option
+
+[![Screenshot-2022-10-07-at-17-26-23.png](https://i.postimg.cc/htBfCXDP/Screenshot-2022-10-07-at-17-26-23.png)](https://postimg.cc/F7Trzsk2)
+
+##### Step 4 : 
+Enter your Github password to confirm the changes.
+
+------------
+
+
+
+
+#### Hurray, you just modified the visibility of your repository 🎉 🚀  
+
+


### PR DESCRIPTION
closes #101 

Added guide/process for How to make a repo private/public.

Path for Markdown for this issue is - [open-source-with-pradumna/pages/How-to/guide/repo-private-public.md](https://github.com/Pradumnasaraf/open-source-with-pradumna/blob/main/pages/How-to/guide/repo-private-public.md)

<a href="https://gitpod.io/#https://github.com/Pradumnasaraf/open-source-with-pradumna/pull/192"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

