### PR TITLE
feat: add dark/light theme toggler

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,24 +3,29 @@
   <head>
     <meta charset="UTF-8" />
     <title>Open Source With Pradumna</title>
-    <link rel="icon" type="image/png" href="./favicon.png">
+    <link rel="icon" type="image/png" href="./favicon.png" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="description" content="Open Source guide" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
     />
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css" />
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+      title="docsify-darklight-theme"
+      type="text/css"
+    />
   </head>
   <body>
     <div id="app"></div>
     <script>
       window.$docsify = {
-        themeColor: '#c9e265',
+        themeColor: "#c9e265",
         name: "Open Source With Pradumna",
-        repo: 'pradumnasaraf/open-source-with-pradumna',
-        loadSidebar: '_layouts/sidebar.md',
-        loadNavbar: '_layouts/navbar.md',
+        repo: "pradumnasaraf/open-source-with-pradumna",
+        loadSidebar: "_layouts/sidebar.md",
+        loadNavbar: "_layouts/navbar.md",
         relativePath: true,
         subMaxLevel: 3,
         search: "auto",
@@ -32,11 +37,24 @@
           depth: 6,
           hideOtherSidebarContent: false,
         },
+        darklightTheme: {
+          bodyFontSize: "16px",
+          dark: {
+            accent: "#c9e265",
+          },
+          light: {
+            accent: "#c9e265",
+          },
+        },
       };
     </script>
     <!-- Docsify v4 -->
     <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-edit-on-github"></script>
     <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+    <script
+      src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+      type="text/javascript"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## 🛠️ Fixes Issue

Closes #197 

## 👨‍💻 Changes proposed

This adds dark/light theme toggler. Now users can switch the site's dark/light theme.
- Added [docsify-darklight-theme](https://github.com/boopathikumar018/docsify-darklight-theme) plugin to the project.
  - Replaced the default stylesheet provided by docsify with the docsify-darklight-theme stylesheet (CDN).
  - Added docsify-darklight-theme javascript file (CDN).
- Configured docsify-darklight-theme plugin to use bodyFontSize of 16px and accent color #c9e265.
- Formatted `index.html` file using prettier.

:link: **[Check out the Live Demo](https://raw.githack.com/vikasganiga05/open-source-with-pradumna/feat-197-theme-toggler/index.html#/)**

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

The `docsify-darklight-theme` plugin is customizable. If anything changes please let me know.
Thank You :pray: 


<a href="https://gitpod.io/#https://github.com/Pradumnasaraf/open-source-with-pradumna/pull/205"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

